### PR TITLE
General improvements in string handling from config check (fixes #4)

### DIFF
--- a/custom_components/config_check/__init__.py
+++ b/custom_components/config_check/__init__.py
@@ -4,7 +4,7 @@ Run the CLI config_check from a service call.
 For more details about this component, please refer to the documentation at
 https://github.com/custom-components/config_check
 """
-import logging
+import re, logging
 from subprocess import Popen, PIPE
 
 NOTIFYID = "1337"
@@ -96,15 +96,20 @@ async def run_check(path):
 
 
 def remove_last_line_from_string(string):
-    """Remove last line from string."""
-    result = string[: string.rfind("\n")]
+    """Remove last line from string if it doesn't contain Invalid Config."""
+    result = string
+    if "Invalid config" not in string:
+        result = string[: string.rfind("\n")]
+
+    """Remove '(See' at end of string."""
+    result = re.sub(". \(See $", ".", result)
+
     return result
 
 
 def clear_result(string):
     """Clear out unwanted stuff from the result."""
     clear_out = [
-        "INFO:homeassistant.util.package:Attempting install of colorlog==4.0.2\n",
         "Testing configuration at /config",
         "homeassistant:",
         "General Errors:",
@@ -119,6 +124,13 @@ def clear_result(string):
     for clear in clear_out:
         string = string.replace(clear, "")
 
-    string = string.replace("Failed config", "**Failed config**")
+    """Remove HA colorlog install attempt, regardless of version """
+    string = re.sub("^.*?INFO:homeassistant.util.package:Attempting install of colorlog.*", "", string)
+
+    """Remove escape characters /"""
+    string = string.encode('ascii', 'ignore').decode('unicode_escape')
+
+    """Remove everything before Failed config."""
+    string = re.sub("^.*?Failed config", "**Failed config**", string)
 
     return string.split("?")[0]


### PR DESCRIPTION
General improvements in string handling from config check
- Use regular expression to exclude colorlog install attempts which sometimes appear
- Remove escape characters (not needed and causing issues in service call)
- Remove everything before string 'Failed config' (it is repeated anyway after)
- Make sure text is not removed if it contains string 'Invalid config'
- Remove '(See' (lost after split by ?)